### PR TITLE
Wrong spelling of forecast_text_tomorrow

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ sensor:
       - condition
       - precipitation
       - forecast_text_today
-      - forecast_text_tommorow
+      - forecast_text_tomorrow
 ```
 
 - A sensor will be created for each of the following conditions, with a default name like `sensor.<name>_temperature`:     
@@ -117,7 +117,7 @@ sensor:
     - `wind_bearing` - The current cardinal wind direction, e.g. "SSW".
     - `precipitation` - precipitation in last 24 hours, in mm.
     - `forecast_text_today` - A textual description of today's forecast
-    - `forecast_text_tommorow` - A textual description of tommorow's forecast
+    - `forecast_text_tomorrow` - A textual description of tomorrow's forecast
 
 *Configuration*
 - name:
@@ -153,7 +153,7 @@ sensor:
       - condition
       - precipitation
       - forecast_text_today
-      - forecast_text_tommorow
+      - forecast_text_tomorrow
 
 ## Camera
 

--- a/configuration.yaml
+++ b/configuration.yaml
@@ -36,7 +36,7 @@ sensor:
       - condition
       - precipitation
       - forecast_text_today
-      - forecast_text_tommorow
+      - forecast_text_tomorrow
 
 weather:
   - platform: dhmz

--- a/custom_components/dhmz/sensor.py
+++ b/custom_components/dhmz/sensor.py
@@ -46,7 +46,7 @@ DEFAULT_NAME = "dhmz"
 CURRENT_SITUATION_API_URL = "https://vrijeme.hr/hrvatska_n.xml"
 PRECIPITATION_API_URL = "https://vrijeme.hr/oborina.xml"
 FORECAST_TODAY_API_URL = "https://prognoza.hr/prognoza_danas.xml"
-FORECAST_TOMMOROW_API_URL = "https://prognoza.hr/prognoza_sutra.xml"
+FORECAST_TOMORROW_API_URL = "https://prognoza.hr/prognoza_sutra.xml"
 FORECAST_3DAYS_API_URL = "https://prognoza.hr/tri/3d_graf_i_simboli.xml"
 FORECAST_7DAYS_API_URL = "https://prognoza.hr/sedam/hrvatska/7d_meteogrami.xml"
 
@@ -71,7 +71,7 @@ SENSOR_TYPES = {
     "precipitation_update_timestamp": ("Precipitation Update Timestamp", None, "Update", str, "kolicina_timestamp", [], "mdi:update", "timestamp", ""),
     # forecast texts
     "forecast_text_today": ("Today forecast", "", "", str, "PrognozaDanas", [], "mdi:calendar-today", "", ""),
-    "forecast_text_tommorow": ("Today forecast", "", "", str, "PrognozaSutra", [], "mdi:calendar-blank", "", ""),
+    "forecast_text_tomorrow": ("Today forecast", "", "", str, "PrognozaSutra", [], "mdi:calendar-blank", "", ""),
 }
 
 FORECAST_DAILY_TYPES = {
@@ -159,7 +159,7 @@ class DhmzSensor(Entity):
     @property
     def state(self):
         """Return the state of the sensor."""
-        if (self.variable == "forecast_text_today") or (self.variable == "forecast_text_tommorow"):
+        if (self.variable == "forecast_text_today") or (self.variable == "forecast_text_tomorrow"):
             return self.probe.get_data(SENSOR_TYPES[self.variable][4])[:255]
         else:
             return self.probe.get_data(SENSOR_TYPES[self.variable][4])
@@ -313,7 +313,7 @@ class DhmzData:
             _LOGGER.debug("Refreshing forecast_daily - prognoza_sutra.xml")
             elems_tm = {}
             # get "prognoza_sutra.xml"
-            tree = etree.parse(urlopen(FORECAST_TOMMOROW_API_URL))
+            tree = etree.parse(urlopen(FORECAST_TOMORROW_API_URL))
             val_condition = tree.xpath("//VW/section/station[@name='" + self._forecast_region_name + "']/param[@name='vrijeme']/@value")[0]
             val_temp_min = tree.xpath("//VW/section/station[@name='" + self._forecast_region_name + "']/param[@name='Tmn']/@value")[0]
             val_temp_max = tree.xpath("//VW/section/station[@name='" + self._forecast_region_name + "']/param[@name='Tmx']/@value")[0]

--- a/custom_components/dhmz/weather.py
+++ b/custom_components/dhmz/weather.py
@@ -188,7 +188,7 @@ class DhmzWeather(WeatherEntity):
             "pressure_tendency": self.dhmz_data.get_data(SENSOR_TYPES["pressure_tendency"][4]),
             "precipitation": self.dhmz_data.get_data(SENSOR_TYPES["precipitation"][4]) if self.dhmz_data.get_data(SENSOR_TYPES["precipitation"][4]) else "0",
             "forecast_today": self.dhmz_data.get_data(SENSOR_TYPES["forecast_text_today"][4]),
-            "forecast_tommorow": self.dhmz_data.get_data(SENSOR_TYPES["forecast_text_tommorow"][4]),
+            "forecast_tomorrow": self.dhmz_data.get_data(SENSOR_TYPES["forecast_text_tomorrow"][4]),
             "forecast_list": self._get_forecast(),
         }
         return(ret)

--- a/www/dhmz-weather-card.js
+++ b/www/dhmz-weather-card.js
@@ -470,7 +470,7 @@ class DhmzWeatherCard extends LitElement {
             </div>
             ${ this.show_tomorrow_text ?
               html `<div class="forecast_text"><div class="label">Sutra:</div></div>
-              <div class="forecast_text"><div class="text">${this.weatherObj.attributes.forecast_tommorow}</div></div>`
+              <div class="forecast_text"><div class="text">${this.weatherObj.attributes.forecast_tomorrow}</div></div>`
               : html ``
             }
           </div>


### PR DESCRIPTION
Biggest problem - HA (Assistants) can't get forecast_text_tomorrow because of wrong spelling -> "forecast_text_tomorrow".
While at it, all tomorrow related grammar errors have been fixed.